### PR TITLE
Require session secret configuration for AfriWrite Mini

### DIFF
--- a/afriwrite-mini/README.md
+++ b/afriwrite-mini/README.md
@@ -9,9 +9,12 @@ Minimal Node.js + Express + SQLite app to publish and sell ebooks (demo).
 ```bash
 cd afriwrite-mini
 npm install
+export SESSION_SECRET="your-secret-value" # required
 npm start
 # open http://localhost:3000
 ```
+
+`SESSION_SECRET` is used to sign session cookies and must be set before starting the server.
 
 ## Demo flow
 1. Register as **Writer**, publish a book (PDF required).

--- a/afriwrite-mini/app.js
+++ b/afriwrite-mini/app.js
@@ -16,6 +16,11 @@ const __dirname = path.dirname(__filename);
 const app = express();
 const PORT = process.env.PORT || 3000;
 
+const SESSION_SECRET = process.env.SESSION_SECRET;
+if (!SESSION_SECRET) {
+  throw new Error("SESSION_SECRET environment variable is required");
+}
+
 // --- Folders ---
 const UPLOAD_DIR = path.join(__dirname, "uploads");
 const PUBLIC_DIR = path.join(__dirname, "public");
@@ -67,7 +72,7 @@ app.use("/covers", express.static(UPLOAD_DIR));
 app.use("/files", express.static(UPLOAD_DIR));
 
 app.use(session({
-  secret: process.env.SESSION_SECRET || "dev-secret-change-me",
+  secret: SESSION_SECRET,
   resave: false,
   saveUninitialized: false,
   cookie: { secure: false } // set true if behind HTTPS proxy


### PR DESCRIPTION
## Summary
- Throw an error if `SESSION_SECRET` is missing and remove fallback value in session middleware
- Document the required `SESSION_SECRET` env variable in README

## Testing
- `node app.js` *(fails without SESSION_SECRET)*
- `SESSION_SECRET=dev node app.js &` *(server starts, then terminated)*
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68bfe4371a788329bb97f6e04aa63b4f