### PR TITLE
Add responsive navigation menu with toggle

### DIFF
--- a/afriwrite-mini/public/styles.css
+++ b/afriwrite-mini/public/styles.css
@@ -20,3 +20,6 @@ h1,h2,h3{margin-top:0}
 .thumb{width:64px;height:64px;object-fit:cover;border-radius:8px;margin-right:12px}
 .flex{display:flex;align-items:center;gap:12px}
 .error{color:#ef4444}
+.nav-menu{display:flex;gap:12px}
+.menu-toggle{display:none;background:none;border:none;color:var(--fg);font-size:24px;cursor:pointer}
+@media(max-width:600px){.nav{flex-wrap:wrap}.nav-menu{flex-direction:column;width:100%;max-height:0;overflow:hidden;transition:max-height .3s ease}.nav-menu.open{max-height:500px}.menu-toggle{display:block}}

--- a/afriwrite-mini/views/layout.ejs
+++ b/afriwrite-mini/views/layout.ejs
@@ -10,7 +10,8 @@
 <body>
   <header class="nav">
     <a class="brand" href="/">AfriWrite Mini</a>
-    <nav>
+    <button class="menu-toggle" aria-label="Toggle menu">☰</button>
+    <nav class="nav-menu">
       <a href="/search">Search</a>
       <% if (currentUser) { %>
         <a href="/library">My Library</a>
@@ -29,5 +30,16 @@
     <%- body %>
   </main>
   <footer class="footer">Built for Nigerian & African writers · Demo MVP</footer>
+  <script>
+    document.addEventListener('DOMContentLoaded', function () {
+      var btn = document.querySelector('.menu-toggle');
+      var menu = document.querySelector('.nav-menu');
+      if (btn && menu) {
+        btn.addEventListener('click', function () {
+          menu.classList.toggle('open');
+        });
+      }
+    });
+  </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- wrap navigation links in a toggleable container with hamburger control
- style navigation for small screens and animate menu slide
- add small script to toggle the menu open and closed

## Testing
- ❌ `npm test` (login tests failing: expected 302, got 403)


------
https://chatgpt.com/codex/tasks/task_e_68bfebf095948329a5411ab783e05b2f