### PR TITLE
Revamp typography and colors for readability

### DIFF
--- a/afriwrite-mini/public/styles.css
+++ b/afriwrite-mini/public/styles.css
@@ -1,6 +1,6 @@
 
-:root { --bg:#0b0b10; --fg:#f3f4f6; --muted:#9ca3af; --card:#111827; --accent:#2563eb; }
-*{box-sizing:border-box} body{margin:0;font-family:system-ui,Segoe UI,Roboto,Arial;background:var(--bg);color:var(--fg)}
+:root { --bg:#0d1117; --fg:#f9fafb; --muted:#94a3b8; --card:#1e293b; --accent:#ff6b6b; }
+*{box-sizing:border-box} body{margin:0;font-family:'Inter',sans-serif;background:var(--bg);color:var(--fg);line-height:1.6}
 a{color:var(--accent);text-decoration:none} a:hover{text-decoration:underline}
 .nav{display:flex;justify-content:space-between;align-items:center;padding:12px 16px;background:#090912;border-bottom:1px solid #1f2937}
 .brand{font-weight:700} .container{max-width:900px;margin:0 auto;padding:16px}
@@ -13,7 +13,7 @@ a{color:var(--accent);text-decoration:none} a:hover{text-decoration:underline}
 .link-btn{background:none;color:var(--accent);border:none;cursor:pointer}
 footer.footer{padding:24px;color:#6b7280;text-align:center}
 label{display:block;margin:10px 0} input, textarea, select, button{width:100%;padding:8px;border-radius:8px;border:1px solid #374151;background:#0f172a;color:#e5e7eb}
-h1,h2,h3{margin-top:0}
+p{line-height:1.6;margin:1em 0} h1,h2,h3{font-family:'Inter',sans-serif;line-height:1.3;margin:1.2em 0 .6em}
 .detail{display:grid;grid-template-columns:200px 1fr;gap:16px}
 .cover-lg{width:100%;height:auto;border-radius:8px;border:1px solid #1f2937}
 .list{list-style:none;padding:0} .list-item{background:var(--card);padding:12px;border-radius:10px;margin:10px 0;border:1px solid #1f2937}

--- a/afriwrite-mini/views/layout.ejs
+++ b/afriwrite-mini/views/layout.ejs
@@ -5,6 +5,9 @@
   <meta charset="utf-8"/>
   <meta name="viewport" content="width=device-width, initial-scale=1"/>
   <title>AfriWrite Mini</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/styles.css">
 </head>
 <body>


### PR DESCRIPTION
## Summary
- introduce vibrant, high-contrast color palette
- add Inter web font and apply to body and headings
- boost line-height and spacing for paragraphs and headings

## Testing
- `npm test` *(fails: Expected 302 but received 403)*

------
https://chatgpt.com/codex/tasks/task_e_68bfec93dfdc8329aa9bd8ef6fe45124