### PR TITLE
feat: add motion-aware card and button states

### DIFF
--- a/afriwrite-mini/public/styles.css
+++ b/afriwrite-mini/public/styles.css
@@ -5,10 +5,12 @@ a{color:var(--accent);text-decoration:none} a:hover{text-decoration:underline}
 .nav{display:flex;justify-content:space-between;align-items:center;padding:12px 16px;background:#090912;border-bottom:1px solid #1f2937}
 .brand{font-weight:700} .container{max-width:900px;margin:0 auto;padding:16px}
 .grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(200px,1fr));gap:16px}
-.card{background:var(--card);border:1px solid #1f2937;border-radius:12px;overflow:hidden;display:flex;flex-direction:column}
+.card{background:var(--card);border:1px solid #1f2937;border-radius:12px;overflow:hidden;display:flex;flex-direction:column;transition:transform .2s ease,box-shadow .2s ease,background-color .2s ease}
+.card:hover,.card:focus{transform:scale(1.02);box-shadow:0 4px 12px rgba(0,0,0,.3);background:#273449}
 .cover{width:100%;height:240px;object-fit:cover;background:#0f172a}
 .card-body{padding:12px} .muted{color:var(--muted)} .price{font-weight:700}
-.btn{display:inline-block;background:var(--accent);color:white;padding:10px 14px;border-radius:8px;border:none;cursor:pointer}
+.btn{display:inline-block;background:var(--accent);color:white;padding:10px 14px;border-radius:8px;border:none;cursor:pointer;transition:transform .2s ease,box-shadow .2s ease,background-color .2s ease}
+.btn:hover,.btn:focus{background:#ff8585;transform:scale(1.05);box-shadow:0 2px 6px rgba(0,0,0,.3)}
 .btn.small{padding:6px 10px;font-size:14px}
 .link-btn{background:none;color:var(--accent);border:none;cursor:pointer}
 footer.footer{padding:24px;color:#6b7280;text-align:center}
@@ -23,3 +25,4 @@ p{line-height:1.6;margin:1em 0} h1,h2,h3{font-family:'Inter',sans-serif;line-hei
 .nav-menu{display:flex;gap:12px}
 .menu-toggle{display:none;background:none;border:none;color:var(--fg);font-size:24px;cursor:pointer}
 @media(max-width:600px){.nav{flex-wrap:wrap}.nav-menu{flex-direction:column;width:100%;max-height:0;overflow:hidden;transition:max-height .3s ease}.nav-menu.open{max-height:500px}.menu-toggle{display:block}}
+@media(prefers-reduced-motion:reduce){.card,.btn{transition:none}.card:hover,.card:focus,.btn:hover,.btn:focus{transform:none}}


### PR DESCRIPTION
## Summary
- add hover/focus transitions to cards with scale, shadow, and background change
- enhance buttons with motion-aware hover/focus styles
- respect `prefers-reduced-motion` to disable animations when users request reduced motion

## Testing
- `npm test` (fails: Expected 302; got 403)


------
https://chatgpt.com/codex/tasks/task_e_68bfedfcf2408329bad212b4e1cb13ce