### PR TITLE
feat: add form utility classes and improve validation

### DIFF
--- a/afriwrite-mini/public/styles.css
+++ b/afriwrite-mini/public/styles.css
@@ -22,6 +22,10 @@ p{line-height:1.6;margin:1em 0} h1,h2,h3{font-family:'Inter',sans-serif;line-hei
 .thumb{width:64px;height:64px;object-fit:cover;border-radius:8px;margin-right:12px}
 .flex{display:flex;align-items:center;gap:12px}
 .error{color:#ef4444}
+.form-group{margin:12px 0}
+.form-actions{margin-top:16px}
+.form-error{color:#ef4444;background:rgba(239,68,68,.1);padding:8px;border-radius:8px;margin:8px 0}
+.form-success{color:#10b981;background:rgba(16,185,129,.1);padding:8px;border-radius:8px;margin:8px 0}
 .nav-menu{display:flex;gap:12px}
 .menu-toggle{display:none;background:none;border:none;color:var(--fg);font-size:24px;cursor:pointer}
 @media(max-width:600px){.nav{flex-wrap:wrap}.nav-menu{flex-direction:column;width:100%;max-height:0;overflow:hidden;transition:max-height .3s ease}.nav-menu.open{max-height:500px}.menu-toggle{display:block}}

--- a/afriwrite-mini/views/login.ejs
+++ b/afriwrite-mini/views/login.ejs
@@ -1,10 +1,11 @@
 
 <h2>Log in</h2>
-<% if (error) { %><p class="error"><%= error %></p><% } %>
+<% if (error) { %><p class="form-error"><%= error %></p><% } %>
+<% if (success) { %><p class="form-success"><%= success %></p><% } %>
 <form method="post">
   <input type="hidden" name="_csrf" value="<%= csrfToken %>">
-  <label>Email <input name="email" type="email" required></label>
-  <label>Password <input name="password" type="password" required></label>
-  <button>Log in</button>
+  <div class="form-group"><label>Email <input name="email" type="email" required></label></div>
+  <div class="form-group"><label>Password <input name="password" type="password" required></label></div>
+  <div class="form-actions"><button>Log in</button></div>
 </form>
 <p>No account? <a href="/register">Register</a></p>

--- a/afriwrite-mini/views/new_book.ejs
+++ b/afriwrite-mini/views/new_book.ejs
@@ -1,12 +1,13 @@
 
 <h2>Publish a new book</h2>
-<% if (error) { %><p class="error"><%= error %></p><% } %>
+<% if (error) { %><p class="form-error"><%= error %></p><% } %>
+<% if (success) { %><p class="form-success"><%= success %></p><% } %>
 <form method="post" enctype="multipart/form-data">
   <input type="hidden" name="_csrf" value="<%= csrfToken %>">
-  <label>Title <input name="title" required></label>
-  <label>Description <textarea name="description"></textarea></label>
-  <label>Price (NGN kobo) <input name="price_ngn" type="number" value="10000" required></label>
-  <label>PDF file <input name="pdf" type="file" accept="application/pdf" required></label>
-  <label>Cover image <input name="cover" type="file" accept="image/*"></label>
-  <button>Publish</button>
+  <div class="form-group"><label>Title <input name="title" required></label></div>
+  <div class="form-group"><label>Description <textarea name="description"></textarea></label></div>
+  <div class="form-group"><label>Price (NGN kobo) <input name="price_ngn" type="number" value="10000" required></label></div>
+  <div class="form-group"><label>PDF file <input name="pdf" type="file" accept="application/pdf" required></label></div>
+  <div class="form-group"><label>Cover image <input name="cover" type="file" accept="image/*"></label></div>
+  <div class="form-actions"><button>Publish</button></div>
 </form>

--- a/afriwrite-mini/views/register.ejs
+++ b/afriwrite-mini/views/register.ejs
@@ -1,17 +1,18 @@
 
 <h2>Create account</h2>
-<% if (error) { %><p class="error"><%= error %></p><% } %>
+<% if (error) { %><p class="form-error"><%= error %></p><% } %>
+<% if (success) { %><p class="form-success"><%= success %></p><% } %>
 <form method="post">
   <input type="hidden" name="_csrf" value="<%= csrfToken %>">
-  <label>Name <input name="name" required></label>
-  <label>Email <input name="email" type="email" required></label>
-  <label>Password <input name="password" type="password" required></label>
-  <label>Role
+  <div class="form-group"><label>Name <input name="name" required></label></div>
+  <div class="form-group"><label>Email <input name="email" type="email" required></label></div>
+  <div class="form-group"><label>Password <input name="password" type="password" required></label></div>
+  <div class="form-group"><label>Role
     <select name="role">
       <option value="READER">Reader</option>
       <option value="WRITER">Writer</option>
     </select>
-  </label>
-  <button>Create account</button>
+  </label></div>
+  <div class="form-actions"><button>Create account</button></div>
 </form>
 <p>Already have an account? <a href="/login">Log in</a></p>


### PR DESCRIPTION
## Summary
- add reusable form utilities and feedback styles
- apply form-group and form-action wrappers to login, register, and new book views
- style success and error messages for clearer validation feedback

## Testing
- `npm test` *(fails: AssertionError 403 !== 302)*

------
https://chatgpt.com/codex/tasks/task_e_68bfee8a28248329a420dfe6a0d1a47f