### PR TITLE
Require csurf middleware and document dependency

### DIFF
--- a/afriwrite-mini/README.md
+++ b/afriwrite-mini/README.md
@@ -15,6 +15,7 @@ npm start
 ```
 
 `SESSION_SECRET` is used to sign session cookies and must be set before starting the server.
+The app relies on the `csurf` package for CSRF protection; running `npm install` will install it as a required dependency.
 
 ## Demo flow
 1. Register as **Writer**, publish a book (PDF required).

--- a/afriwrite-mini/app.js
+++ b/afriwrite-mini/app.js
@@ -9,16 +9,7 @@ import Database from "better-sqlite3";
 import bcrypt from "bcryptjs";
 import fs from "fs";
 import { PDFDocument, rgb, StandardFonts } from "pdf-lib";
-
-let csurf;
-try {
-  ({ default: csurf } = await import("csurf"));
-} catch {
-  csurf = () => (req, res, next) => {
-    req.csrfToken = () => "test-token";
-    next();
-  };
-}
+import csurf from "csurf";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -185,13 +176,13 @@ app.post("/register", async (req, res) => {
 });
 
 // Login
-app.get("/login", (req, res) => res.render("login", { error: null }));
+app.get("/login", (req, res) => res.render("login", { error: null, success: null }));
 app.post("/login", async (req, res) => {
   const { email, password } = req.body;
   const user = db.prepare("SELECT * FROM users WHERE email=?").get(email.toLowerCase());
-  if (!user) return res.render("login", { error: "Invalid credentials" });
+  if (!user) return res.render("login", { error: "Invalid credentials", success: null });
   const ok = await bcrypt.compare(password, user.password_hash);
-  if (!ok) return res.render("login", { error: "Invalid credentials" });
+  if (!ok) return res.render("login", { error: "Invalid credentials", success: null });
   req.session.user = { id: user.id, email: user.email, name: user.name, role: user.role };
   const nextRaw = req.query.next;
   const next = (typeof nextRaw === "string" && nextRaw.startsWith("/") && !nextRaw.includes("//")) ? nextRaw : "/";

--- a/afriwrite-mini/test/login.test.js
+++ b/afriwrite-mini/test/login.test.js
@@ -31,13 +31,19 @@ async function attemptLogin(next) {
   const server = app.listen();
   const port = server.address().port;
   const base = `http://127.0.0.1:${port}`;
+  const loginPage = await fetch(`${base}/login`);
+  const cookie = loginPage.headers.get('set-cookie')?.split(';')[0] || '';
+  const html = await loginPage.text();
+  const match = html.match(/name="_csrf" value="([^"]+)"/);
+  const token = match ? match[1] : '';
 
   const res = await fetch(`${base}/login?next=${encodeURIComponent(next)}`, {
     method: 'POST',
     headers: {
-      'Content-Type': 'application/x-www-form-urlencoded'
+      'Content-Type': 'application/x-www-form-urlencoded',
+      Cookie: cookie
     },
-    body: new URLSearchParams({ email, password }),
+    body: new URLSearchParams({ email, password, _csrf: token }),
     redirect: 'manual'
   });
 


### PR DESCRIPTION
## Summary
- import csurf directly and remove optional try/catch
- document csurf as a required dependency
- update login tests to include CSRF tokens

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bff5cbf0508329bc71eba6f2effba9