### PR TITLE
Improve session security

### DIFF
--- a/afriwrite-mini/README.md
+++ b/afriwrite-mini/README.md
@@ -16,6 +16,7 @@ npm start
 
 `SESSION_SECRET` is used to sign session cookies and must be set before starting the server.
 The app relies on the `csurf` package for CSRF protection; running `npm install` will install it as a required dependency.
+In production, the app must run behind HTTPS so the session cookie's `secure` flag can be enabled.
 
 ## Demo flow
 1. Register as **Writer**, publish a book (PDF required).

--- a/afriwrite-mini/app.js
+++ b/afriwrite-mini/app.js
@@ -76,7 +76,7 @@ app.use(session({
   secret: SESSION_SECRET,
   resave: false,
   saveUninitialized: false,
-  cookie: { secure: false } // set true if behind HTTPS proxy
+  cookie: { httpOnly: true, sameSite: 'lax', secure: process.env.NODE_ENV === 'production' }
 }));
 
 const csrfProtection = csurf();


### PR DESCRIPTION
## Summary
- secure session cookies by enforcing httpOnly, sameSite=lax and secure in production
- note in docs that production deployments require HTTPS to enable secure cookies

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bff968bf808329afce877b5aeedd79